### PR TITLE
[CHD file support] Prefer first data track instead of cue/gdi file itself

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 TOSEC_URL=		https://www.tosecdev.org/downloads/category/40-2017-08-01?download=79:tosec-dat-pack-complete-2480-tosec-v2017-08-01
 
 REDUMP_URL=		http://redump.org/datfile
+REDUMP_CUES_URL=	http://redump.org/cues
+REDUMP_GDI_URL=	http://redump.org/gdi
 
 REDUMP_SYSTEMS+=	xbox-bios
 REDUMP_SYSTEMS+=	gc-bios
@@ -43,12 +45,18 @@ default:
 	@echo "    make input/tosec"
 
 input/redump:
-	mkdir temp || true
 	for i in $(REDUMP_SYSTEMS); do \
-		curl -L $(REDUMP_URL)/$$i -o temp/$$i ;\
-		unzip -o temp/$$i -d temp ;\
+		mkdir -p temp/$$i/; \
+		curl -L $(REDUMP_URL)/$$i -o temp/dat.$$i.zip ;\
+		if [ "$$i" = "dc" ]; then \
+			curl -L $(REDUMP_GDI_URL)/$$i -o temp/cue.$$i.zip ;\
+		else \
+			curl -L $(REDUMP_CUES_URL)/$$i -o temp/cue.$$i.zip ;\
+		fi; \
+		unzip -o temp/dat.$$i.zip -d temp/$$i || true ;\
+		unzip -o temp/cue.$$i.zip -d temp/$$i || true ;\
 	done
-	mkdir input/redump && mv temp/*.dat input/redump
+	mv temp input/redump
 
 input/tosec: temp/tosec.zip
 	unzip -o temp/tosec.zip -d input/tosec

--- a/dats.json
+++ b/dats.json
@@ -13,12 +13,12 @@
 	},
 	"libretro-database/metadat/redump/NEC - PC Engine CD - TurboGrafx-CD": {
 		"files": [
-			"input/redump/dats/NEC - PC Engine CD*"
+			"input/redump/pce/NEC - PC Engine CD*.dat"
 		]
 	},
 	"libretro-database/metadat/redump/Microsoft - Xbox": {
 		"files": [
-			"input/redump/dats/Microsoft - Xbox (*"
+			"input/redump/xbox/Microsoft - Xbox (*.dat"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/NEC - PC-FX": {
@@ -29,12 +29,12 @@
 	},
 	"libretro-database/metadat/redump/NEC - PC-FX": {
 		"files": [
-			"input/redump/dats/NEC - PC-FX*"
+			"input/redump/pc-fx/NEC - PC-FX*.dat"
 		]
 	},
 	"libretro-database/metadat/redump/SNK - Neo Geo CD": {
 		"files": [
-			"input/redump/dats/SNK - Neo Geo CD (*"
+			"input/redump/ngcd/SNK - Neo Geo CD (*.dat"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Nintendo - GameCube": {
@@ -45,12 +45,12 @@
 	},
 	"libretro-database/metadat/redump/Nintendo - GameCube": {
 		"files": [
-			"input/redump/dats/Nintendo - GameCube (*"
+			"input/redump/gc/Nintendo - GameCube (*.dat"
 		]
 	},
 	"libretro-database/metadat/redump/Nintendo - Wii": {
 		"files": [
-			"input/redump/dats/Nintendo - Wii (*"
+			"input/redump/Nintendo - Wii (*"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Sega - Dreamcast": {
@@ -61,7 +61,7 @@
 	},
 	"libretro-database/metadat/redump/Sega - Dreamcast": {
 		"files": [
-			"input/redump/dats/Sega - Dreamcast*"
+			"input/redump/dc/Sega - Dreamcast*.dat"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Sega - Mega-CD - Sega CD": {
@@ -73,7 +73,7 @@
 	},
 	"libretro-database/metadat/redump/Sega - Mega-CD - Sega CD": {
 		"files": [
-			"input/redump/dats/Sega - Mega-CD*"
+			"input/redump/scd/Sega - Mega-CD*.dat"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Sega - Saturn": {
@@ -85,7 +85,7 @@
 	},
 	"libretro-database/metadat/redump/Sega - Saturn": {
 		"files": [
-			"input/redump/dats/Sega - Saturn*"
+			"input/redump/ss/Sega - Saturn*.dat"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Sony - PlayStation": {
@@ -96,17 +96,17 @@
 	},
 	"libretro-database/metadat/redump/Sony - PlayStation": {
 		"files": [
-			"input/redump/dats/Sony - PlayStation (*"
+			"input/redump/psx/Sony - PlayStation (*.dat"
 		]
 	},
 	"libretro-database/metadat/redump/Sony - PlayStation 2": {
 		"files": [
-			"input/redump/dats/Sony - PlayStation 2 (*"
+			"input/redump/ps2/Sony - PlayStation 2 (*.dat"
 		]
 	},
 	"libretro-database/metadat/redump/Sony - PlayStation Portable": {
 		"files": [
-			"input/redump/dats/Sony - PlayStation Portable (*"
+			"input/redump/Sony - PlayStation Portable (*"
 		]
 	},
 	"libretro-database/metadat/libretro-dats/Sinclair - ZX Spectrum": {
@@ -128,7 +128,7 @@
 	},
 	"libretro-database/metadat/redump/The 3DO Company - 3DO": {
 		"files": [
-			"input/redump/dats/Panasonic - 3DO*"
+			"input/redump/3d0/Panasonic - 3DO*.dat"
 		]
 	},
 	"libretro-database/metadat/no-intro/Atari - 2600": {


### PR DESCRIPTION
This is a companion PR to https://github.com/libretro/RetroArch/pull/5445.  This should only be merged if/when that PR is accepted.  This change is necessary because CHD files do not preserve the original `.cue` or `.gdi` file, so the CRC for the first data track needs to be looked up instead.
