### PR TITLE
Add missing .cue files from redump, expand systems

### DIFF
--- a/dats.json
+++ b/dats.json
@@ -1,112 +1,97 @@
 {
 	"database/metadat/redump/Microsoft - Xbox": {
 		"files": [
-			"input/redump/Microsoft - Xbox - Dat*.dat"
+			"input/redump/xbox/Microsoft - Xbox - Dat*.dat"
 		]
 	},
 	"database/metadat/redump/Microsoft - Xbox 360": {
 		"files": [
-			"input/redump/Microsoft - Xbox 360*.dat"
-		]
-	},
-	"database/metadat/redump/Microsoft - Xbox One": {
-		"files": [
-			"input/redump/Microsoft - Xbox One*.dat"
+			"input/redump/xbox360/Microsoft - Xbox 360*.dat"
 		]
 	},
 	"database/metadat/redump/Philips - CD-i": {
 		"files": [
-			"input/redump/Philips - CD-i*.dat"
+			"input/redump/cdi/Philips - CD-i*.dat"
 		]
 	},
 	"database/metadat/redump/NEC - PC Engine CD - TurboGrafx-CD": {
 		"files": [
-			"input/redump/NEC - PC Engine CD*.dat"
+			"input/redump/pce/NEC - PC Engine CD*.dat"
 		]
 	},
 	"database/metadat/redump/NEC - PC-98": {
 		"files": [
-			"input/redump/NEC - PC-98*.dat"
+			"input/redump/pc-98/NEC - PC-98*.dat"
 		]
 	},
 	"database/metadat/redump/NEC - PC-FX": {
 		"files": [
-			"input/redump/NEC - PC-FX*.dat"
+			"input/redump/pc-fx/NEC - PC-FX*.dat"
 		]
 	},
 	"database/metadat/redump/SNK - Neo Geo CD": {
 		"files": [
-			"input/redump/SNK - Neo Geo CD - D*.dat"
+			"input/redump/ngcd/SNK - Neo Geo CD - D*.dat"
 		]
 	},
 	"database/metadat/redump/Nintendo - GameCube": {
 		"files": [
-			"input/redump/Nintendo - GameCube - D*.dat"
+			"input/redump/gc/Nintendo - GameCube - D*.dat"
 		]
 	},
 	"database/metadat/redump/Nintendo - Wii": {
 		"files": [
-			"input/redump/Nintendo - Wii - *"
-		]
-	},
-	"database/metadat/redump/Nintendo - Wii U": {
-		"files": [
-			"input/redump/Nintendo - Wii U - *"
+			"input/redump/wii/Nintendo - Wii - *"
 		]
 	},
 	"database/metadat/redump/Sega - Dreamcast": {
 		"files": [
-			"input/redump/Sega - Dreamcast*.dat"
+			"input/redump/dc/Sega - Dreamcast*.dat"
 		]
 	},
 	"database/metadat/redump/Sega - Mega-CD - Sega CD": {
 		"files": [
-			"input/redump/Sega - Mega*.dat"
+			"input/redump/mcd/Sega - Mega*.dat"
 		]
 	},
 	"database/metadat/redump/Sega - Naomi": {
 		"files": [
-			"input/redump/Arcade - Sega - Naomi - D*.dat"
+			"input/redump/naomi/Arcade - Sega - Naomi - D*.dat"
 		]
 	},
 	"database/metadat/redump/Sega - Naomi 2": {
 		"files": [
-			"input/redump/Arcade - Sega - Naomi 2 - D*.dat"
+			"input/redump/naomi2/Arcade - Sega - Naomi 2 - D*.dat"
 		]
 	},
 	"database/metadat/redump/Sega - Saturn": {
 		"files": [
-			"input/redump/Sega - Saturn*.dat"
+			"input/redump/ss/Sega - Saturn*.dat"
 		]
 	},
 	"database/metadat/redump/Sony - PlayStation": {
 		"files": [
-			"input/redump/Sony - PlayStation - Dat*.dat"
+			"input/redump/psx/Sony - PlayStation - Dat*.dat"
 		]
 	},
 	"database/metadat/redump/Sony - PlayStation 2": {
 		"files": [
-			"input/redump/Sony - PlayStation 2 - Dat*.dat"
+			"input/redump/ps2/Sony - PlayStation 2 - Dat*.dat"
 		]
 	},
 	"database/metadat/redump/Sony - PlayStation 3": {
 		"files": [
-			"input/redump/Sony - PlayStation 3 - Dat*.dat"
-		]
-	},
-	"database/metadat/redump/Sony - PlayStation 4": {
-		"files": [
-			"input/redump/Sony - PlayStation 4 - Dat*.dat"
+			"input/redump/ps3/Sony - PlayStation 3 - Dat*.dat"
 		]
 	},
 	"database/metadat/redump/Sony - PlayStation Portable": {
 		"files": [
-			"input/redump/Sony - PlayStation Portable - Dat*"
+			"input/redump/psp/Sony - PlayStation Portable - Dat*"
 		]
 	},
 	"database/metadat/redump/The 3DO Company - 3DO": {
 		"files": [
-			"input/redump/Panasonic - 3DO*.dat"
+			"input/redump/3do/Panasonic - 3DO*.dat"
 		]
 	},
 	"database/metadat/libretro-dats/Nintendo - Super Nintendo Entertainment System": {

--- a/download.js
+++ b/download.js
@@ -98,52 +98,72 @@ function extractFile(source, dest) {
 }
 
 async function redumpDownload(element) {
-	await downloadFile(`http://redump.org/datfile/${element}/serial,version`, `input/redump/${element}.zip`)
+	await downloadFile(`http://redump.org/datfile/${element}/serial,version`, `input/redump/${element}/dat.zip`)
+	await downloadFile(`http://redump.org/cues/${element}/serial,version`, `input/redump/${element}/cue.zip`)
 }
 
 async function redump() {
 	console.log('redump!')
 	mkdirp.sync('input/redump')
 	const systems = [
-		'cdi',
+		'arch',
 		'mac',
+		'ajcd',
 		'pippin',
+		'qis',
 		'acd',
 		'cd32',
 		'cdtv',
 		'fmt',
-		'3do',
+		'fpp',
 		'pc',
+		'ite',
+		'kea',
+		'kfb',
+		'ksgv',
+		'ixl',
 		'hs',
+		'vis',
 		'xbox',
+		'xbox360',
+		'trf',
+		'ns246',
+		'pce',
 		'pc-88',
 		'pc-98',
 		'pc-fx',
-		'pce',
-		'psp',
+		'ngcd',
 		'gc',
+		'wii',
 		'palm',
-		'mcd',
 		'3do',
 		'cdi',
 		'photo-cd',
+		'psxgs',
+		'ppc',
+		'chihiro',
 		'dc',
+		'mcd',
+		'naomi',
+		'naomi2',
+		'sp21',
+		'sre',
+		'sre2',
 		'ss',
-		'ngcd',
+		'x68k',
 		'psx',
 		'ps2',
+		'ps3',
+		'psp',
+		'quizard',
+		'ksite',
+		'nuon',
 		'vflash',
-		'trf',
-		'chihiro',
-		'lindbergh',
-		'naomi',
-		'naomi2'
+		'gamewave'
 	]
 	for (let element of systems) {
 		console.log(element)
 		await redumpDownload(element)
-		//await downloadFile(`http://redump.org/datfile/${system}/`, `input/redump/${system}.zip`)
-		//await extractFile(`input/redump/${system}.zip`, 'input/redump')
 	}
 	/*
 	systems.forEach(async (system) => {


### PR DESCRIPTION
I found this issue when trying to fix PC Engine CD scanning. On RetroArch, scanning of CD systems is made first by comparing a serial number, and if that fails, comparing the CRC. I could not find the serial anywhere on PCE-CD images, so CRC comparison is the only way.

However, RetroArch expects the CRC of the biggest data track from the image. The .dat files are not sufficient, you also need the .cue files to know which tracks to compare the CRC.

This PR adds the missing .cue files to all provided redump systems. It also fetches every single .dat and .cue file that redump offers, increasing the databases for the systems:
- Xbox
- Xbox 360
- CD-i
- PCE CD
- PC-98
- PC-FX
- NGCD
- GC
- Wii
- DC
- MCD
- NAOMI
- NAOMI2
- SS
- PSX
- PS2
- PS3
- PSP
- 3DO

More databases can be improved with the remaining redump .dat and .cue files, they only need a compatible core for the system.

Tested on .chd files.

Closes https://github.com/libretro/libretro-database/issues/831 .