### PR TITLE
TOSEC update for CD32 turned off

### DIFF
--- a/dats.json
+++ b/dats.json
@@ -331,7 +331,7 @@
 		]
 	},
 	"database/metadat/tosec/Commodore - CD32": {
-		"files": [
+		"files-ignore-missing-serial": [
 			"input/tosec/TOSEC-ISO/Commodore Amiga CD32 - Games*"
 		]
 	},


### PR DESCRIPTION
TOSEC data for CD32 moved to extra.dat