### PR TITLE
fix: renest parens around G.Darius, PSO checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,11 +66,11 @@ function validEntry(gameName) {
 
 	// The serial conflicts with Sonic Adventure 2
 	// https://github.com/libretro/libretro-database/issues/1444
-	if (gameName.indexOf('Phantasy Star Online' >= 0) && gameName.indexOf('(Rev B)') >= 0) {
+	if (gameName.indexOf('Phantasy Star Online') >= 0 && gameName.indexOf('(Rev B)') >= 0) {
 		return false
 	}
 
-	if (gameName.indexOf('G. Darius (USA) (Beta)' >= 0)) {
+	if (gameName.indexOf('G. Darius (USA) (Beta)') >= 0) {
 		return false
 	}
 


### PR DESCRIPTION
Existing checks seem to reject all names (including "Super Mario Bros") as being too Darius-like; the PSO has probably only been affecting "(Rev B)".