### PR TITLE
Add Epoch Cassette Vision from TOSEC

### DIFF
--- a/dats.json
+++ b/dats.json
@@ -174,6 +174,11 @@
 			"input/tosec/TOSEC/Amstrad GX4000 - Games*"
 		]
 	},
+	"database/metadat/tosec/Epoch - Cassette Vision": {
+		"files": [
+			"input/tosec/TOSEC/Epoch Cassette Vision - Games*"
+		]
+	},
 	"database/metadat/tosec/Infocom - Z-Machine": {
 		"files": [
 			"input/tosec/TOSEC/Infocom Z-Machine - *"

--- a/index.js
+++ b/index.js
@@ -602,6 +602,9 @@ function getGamesFromXml(filepath, dat) {
 				else if (extname == '.mg1') {
 					// Ignore
 				}
+				else if (extname == '.ptn777') {
+					// Ignore, Epoch Cassette Vision's bin777 is more important
+				}
 				else if (extname.length == 0) {
 					// Ignore zero extension
 				}


### PR DESCRIPTION
Based on 
* https://github.com/mittonk/epoch-cassette-vision-dat/blob/main/Epoch%20Cassette%20Vision%20-%20Games%20(TNC).dat

which has been submitted to TOSEC, but not yet released as part of a TOSEC release.

Works locally when added to my RetroArch tree (with pd777 and https://github.com/libretro/libretro-super/pull/1949 installed).

Would it be better to wait for a release?
Should I be filing PRs on RobLoach/libretro-dats or libretro/libretro-database ?